### PR TITLE
develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+## v0.1.4
+
+- Add string constants example
+- `rustdoc-scrape-examples` の設定を削除
+
 ## v0.1.3
 
 - `bump_version` バイナリを含めないように修正

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,14 +13,3 @@ edition = "2021"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"
-
-
-[package.metadata.docs.rs]
-features = ["unstable-doc"]
-rustdoc-args = ["--cfg", "docsrs"]
-cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
-
-
-[[example]]
-name = "input"
-doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspy"
-version = "0.1.3"
+version = "0.1.4"
 description = "Pythonic interface for Rust"
 repository = "https://github.com/seijinrosen/rspy"
 readme = "README.md"

--- a/examples/string_constants.rs
+++ b/examples/string_constants.rs
@@ -1,0 +1,9 @@
+use rspy::string::{ASCII_LOWERCASE, ASCII_UPPERCASE};
+
+fn main() {
+    let lowercase = ASCII_LOWERCASE;
+    println!("{lowercase}");
+
+    let uppercase = ASCII_UPPERCASE;
+    println!("{uppercase}");
+}


### PR DESCRIPTION
- Add string constants example
- rustdoc-scrape-examples の設定を一旦削除
- Bump version from v0.1.3 to v0.1.4
