### PR TITLE
develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.1.7
+
+- `PyEnumerate` を削除し、`enumerate` は `Zip` を返すように変更
+
 ## v0.1.6
 
 - Impl enumerate: array, vector

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.1.7
 
 - `PyEnumerate` を削除し、`enumerate` は `Zip` を返すように変更
+- Add time::sleep
 
 ## v0.1.6
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ edition = "2021"
 
 [dev-dependencies]
 pretty_assertions = "1.3.0"
+tempfile = "3.3.0"
 
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,15 @@ edition = "2021"
 pretty_assertions = "1.3.0"
 
 
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]
+cargo-args = ["-Zunstable-options", "-Zrustdoc-scrape-examples"]
+
+
+[lib]
+doc-scrape-examples = true
+
+
 [[example]]
 name = "input"
 doc-scrape-examples = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rspy"
-version = "0.1.6"
+version = "0.1.7"
 description = "Pythonic interface for Rust"
 repository = "https://github.com/seijinrosen/rspy"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -24,3 +24,9 @@ rspy = "0"
 | [input](https://docs.python.org/ja/3/library/functions.html#input)                                | [rspy::input](https://docs.rs/rspy/latest/rspy/fn.input.html)                                          |
 | [string.ascii_lowercase](https://docs.python.org/ja/3/library/string.html#string.ascii_lowercase) | [rspy::string::ASCII_LOWERCASE](https://docs.rs/rspy/latest/rspy/string/constant.ASCII_LOWERCASE.html) |
 | [string.ascii_uppercase](https://docs.python.org/ja/3/library/string.html#string.ascii_uppercase) | [rspy::string::ASCII_UPPERCASE](https://docs.rs/rspy/latest/rspy/string/constant.ASCII_UPPERCASE.html) |
+
+## TODO
+
+- [pathlib.Path.mkdir][python.pathlib.path.mkdir]
+
+[python.pathlib.path.mkdir]: https://docs.python.org/ja/3/library/pathlib.html#pathlib.Path.mkdir

--- a/README.md
+++ b/README.md
@@ -18,15 +18,22 @@ rspy = "0"
 
 ## Currently available
 
-| Python                                                                                            | Rust                                                                                                   |
-| ------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
-| [enumerate](https://docs.python.org/ja/3/library/functions.html#enumerate)                        | rspy::Enumerator::enumerate                                                                            |
-| [input](https://docs.python.org/ja/3/library/functions.html#input)                                | [rspy::input](https://docs.rs/rspy/latest/rspy/fn.input.html)                                          |
-| [string.ascii_lowercase](https://docs.python.org/ja/3/library/string.html#string.ascii_lowercase) | [rspy::string::ASCII_LOWERCASE](https://docs.rs/rspy/latest/rspy/string/constant.ASCII_LOWERCASE.html) |
-| [string.ascii_uppercase](https://docs.python.org/ja/3/library/string.html#string.ascii_uppercase) | [rspy::string::ASCII_UPPERCASE](https://docs.rs/rspy/latest/rspy/string/constant.ASCII_UPPERCASE.html) |
+| Python                                                  | Rust                                                         |
+| ------------------------------------------------------- | ------------------------------------------------------------ |
+| [enumerate][python.enumerate]                           | rspy::Enumerator::enumerate                                  |
+| [input][python.input]                                   | [rspy::input][rspy.input]                                    |
+| [string.ascii_lowercase][python.string.ascii_lowercase] | [rspy::string::ASCII_LOWERCASE][rspy.string.ascii_lowercase] |
+| [string.ascii_uppercase][python.string.ascii_uppercase] | [rspy::string::ASCII_UPPERCASE][rspy.string.ascii_uppercase] |
 
 ## TODO
 
 - [pathlib.Path.mkdir][python.pathlib.path.mkdir]
 
+[python.enumerate]: https://docs.python.org/ja/3/library/functions.html#enumerate
+[python.input]: https://docs.python.org/ja/3/library/functions.html#input
 [python.pathlib.path.mkdir]: https://docs.python.org/ja/3/library/pathlib.html#pathlib.Path.mkdir
+[python.string.ascii_lowercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_lowercase
+[python.string.ascii_uppercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_uppercase
+[rspy.input]: https://docs.rs/rspy/latest/rspy/fn.input.html
+[rspy.string.ascii_lowercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_LOWERCASE.html
+[rspy.string.ascii_uppercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_UPPERCASE.html

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ rspy = "0"
 | [builtins.input]         | [rspy::input]                   |
 | [string.ascii_lowercase] | [rspy::string::ASCII_LOWERCASE] |
 | [string.ascii_uppercase] | [rspy::string::ASCII_UPPERCASE] |
+| [time.sleep]             | rspy::time::sleep               |
 
 ## TODO
 
@@ -34,6 +35,7 @@ rspy = "0"
 [pathlib.path.mkdir]: https://docs.python.org/ja/3/library/pathlib.html#pathlib.Path.mkdir
 [string.ascii_lowercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_lowercase
 [string.ascii_uppercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_uppercase
+[time.sleep]: https://docs.python.org/ja/3/library/time.html#time.sleep
 [rspy::enumerator::enumerate]: https://docs.rs/rspy/latest/rspy/trait.Enumerator.html#tymethod.enumerate
 [rspy::input]: https://docs.rs/rspy/latest/rspy/fn.input.html
 [rspy::string::ascii_lowercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_LOWERCASE.html

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ rspy = "0"
 
 ## Currently available
 
-| Python                                                  | Rust                                                         |
-| ------------------------------------------------------- | ------------------------------------------------------------ |
-| [enumerate][python.enumerate]                           | rspy::Enumerator::enumerate                                  |
-| [input][python.input]                                   | [rspy::input][rspy.input]                                    |
-| [string.ascii_lowercase][python.string.ascii_lowercase] | [rspy::string::ASCII_LOWERCASE][rspy.string.ascii_lowercase] |
-| [string.ascii_uppercase][python.string.ascii_uppercase] | [rspy::string::ASCII_UPPERCASE][rspy.string.ascii_uppercase] |
+| Python                   | Rust                            |
+| ------------------------ | ------------------------------- |
+| [builtins.enumerate]     | rspy::Enumerator::enumerate     |
+| [builtins.input]         | [rspy::input]                   |
+| [string.ascii_lowercase] | [rspy::string::ASCII_LOWERCASE] |
+| [string.ascii_uppercase] | [rspy::string::ASCII_UPPERCASE] |
 
 ## TODO
 
-- [pathlib.Path.mkdir][python.pathlib.path.mkdir]
+- [pathlib.Path.mkdir]
 
-[python.enumerate]: https://docs.python.org/ja/3/library/functions.html#enumerate
-[python.input]: https://docs.python.org/ja/3/library/functions.html#input
-[python.pathlib.path.mkdir]: https://docs.python.org/ja/3/library/pathlib.html#pathlib.Path.mkdir
-[python.string.ascii_lowercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_lowercase
-[python.string.ascii_uppercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_uppercase
-[rspy.input]: https://docs.rs/rspy/latest/rspy/fn.input.html
-[rspy.string.ascii_lowercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_LOWERCASE.html
-[rspy.string.ascii_uppercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_UPPERCASE.html
+[builtins.enumerate]: https://docs.python.org/ja/3/library/functions.html#enumerate
+[builtins.input]: https://docs.python.org/ja/3/library/functions.html#input
+[pathlib.path.mkdir]: https://docs.python.org/ja/3/library/pathlib.html#pathlib.Path.mkdir
+[string.ascii_lowercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_lowercase
+[string.ascii_uppercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_uppercase
+[rspy::input]: https://docs.rs/rspy/latest/rspy/fn.input.html
+[rspy::string::ascii_lowercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_LOWERCASE.html
+[rspy::string::ascii_uppercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_UPPERCASE.html

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ rspy = "0"
 
 | Python                   | Rust                            |
 | ------------------------ | ------------------------------- |
-| [builtins.enumerate]     | rspy::Enumerator::enumerate     |
+| [builtins.enumerate]     | [rspy::Enumerator::enumerate]   |
 | [builtins.input]         | [rspy::input]                   |
 | [string.ascii_lowercase] | [rspy::string::ASCII_LOWERCASE] |
 | [string.ascii_uppercase] | [rspy::string::ASCII_UPPERCASE] |
@@ -34,6 +34,7 @@ rspy = "0"
 [pathlib.path.mkdir]: https://docs.python.org/ja/3/library/pathlib.html#pathlib.Path.mkdir
 [string.ascii_lowercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_lowercase
 [string.ascii_uppercase]: https://docs.python.org/ja/3/library/string.html#string.ascii_uppercase
+[rspy::enumerator::enumerate]: https://docs.rs/rspy/latest/rspy/trait.Enumerator.html#tymethod.enumerate
 [rspy::input]: https://docs.rs/rspy/latest/rspy/fn.input.html
 [rspy::string::ascii_lowercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_LOWERCASE.html
 [rspy::string::ascii_uppercase]: https://docs.rs/rspy/latest/rspy/string/constant.ASCII_UPPERCASE.html

--- a/command-history.txt
+++ b/command-history.txt
@@ -8,3 +8,4 @@ cargo add --dev pretty_assertions
 poetry init
 poetry add --group=dev bandit
 poetry add --group=dev black
+cargo add --dev tempfile

--- a/cspell.json
+++ b/cspell.json
@@ -8,6 +8,7 @@
     "doctest",
     "esbenp",
     "nocapture",
+    "pathlib",
     "Pythonic",
     "rspy",
     "rustdoc",

--- a/cspell.json
+++ b/cspell.json
@@ -1,5 +1,6 @@
 {
   "words": [
+    "builtins",
     "clippy",
     "cobertura",
     "codecov",

--- a/cspell.json
+++ b/cspell.json
@@ -14,6 +14,7 @@
     "rspy",
     "rustdoc",
     "seijinrosen",
+    "tempfile",
     "venv",
     "Zrustdoc",
     "Zunstable"

--- a/examples/string_constants.py
+++ b/examples/string_constants.py
@@ -1,0 +1,4 @@
+from string import ascii_lowercase, ascii_uppercase
+
+print(ascii_lowercase)
+print(ascii_uppercase)

--- a/examples/time_sleep.py
+++ b/examples/time_sleep.py
@@ -1,0 +1,7 @@
+from time import sleep
+
+print("Sleeping for 3 seconds...")
+
+sleep(3)
+
+print("I woke up!")

--- a/examples/time_sleep.rs
+++ b/examples/time_sleep.rs
@@ -1,0 +1,9 @@
+use rspy::time::sleep;
+
+fn main() {
+    println!("Sleeping for 3 seconds...");
+
+    sleep(3);
+
+    println!("I woke up!");
+}

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -66,11 +66,27 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     #[test]
-    fn enumerate_works() {
+    fn str_enumerate_works() {
         let mut index_vec = vec![];
         let mut char_vec = vec![];
 
         for (i, ch) in "abcde".enumerate(-3) {
+            index_vec.push(i);
+            char_vec.push(ch);
+        }
+
+        assert_eq!(index_vec, [-3, -2, -1, 0, 1]);
+        assert_eq!(char_vec, ['a', 'b', 'c', 'd', 'e']);
+    }
+
+    #[test]
+    fn string_enumerate_works() {
+        let mut index_vec = vec![];
+        let mut char_vec = vec![];
+
+        let s = "abcde".to_string();
+
+        for (i, ch) in s.enumerate(-3) {
             index_vec.push(i);
             char_vec.push(ch);
         }

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -4,16 +4,15 @@ use std::{iter::Zip, ops::Range, slice::Iter, str::Chars};
 pub trait Enumerator<'a> {
     type Item;
 
+    /// インデックス付きでイテレートします。
+    ///
+    /// Python とは異なり、`start` は 0 の場合でも必須です。
     fn enumerate(&'a self, start: i32) -> Zip<Range<i32>, Self::Item>;
 }
 
 impl<'a> Enumerator<'a> for str {
     type Item = Chars<'a>;
 
-    /// インデックス付きでイテレートします。
-    ///
-    /// Python とは異なり、`start` は 0 の場合でも必須です。
-    ///
     /// # Examples
     ///
     /// ```

--- a/src/enumerate.rs
+++ b/src/enumerate.rs
@@ -1,34 +1,10 @@
-use std::{slice::Iter, str::Chars};
-
-pub struct PyEnumerate<I> {
-    iter: I,
-    count: i32,
-}
-impl<I> PyEnumerate<I> {
-    fn new(iter: I, start: i32) -> PyEnumerate<I> {
-        PyEnumerate { iter, count: start }
-    }
-}
-
-impl<I> Iterator for PyEnumerate<I>
-where
-    I: Iterator,
-{
-    type Item = (i32, <I as Iterator>::Item);
-
-    fn next(&mut self) -> Option<(i32, <I as Iterator>::Item)> {
-        let a = self.iter.next()?;
-        let i = self.count;
-        self.count += 1;
-        Some((i, a))
-    }
-}
+use std::{iter::Zip, ops::Range, slice::Iter, str::Chars};
 
 /// `enumerate` を実装するためのトレイト。
 pub trait Enumerator<'a> {
     type Item;
 
-    fn enumerate(&'a self, start: i32) -> PyEnumerate<Self::Item>;
+    fn enumerate(&'a self, start: i32) -> Zip<Range<i32>, Self::Item>;
 }
 
 impl<'a> Enumerator<'a> for str {
@@ -54,32 +30,32 @@ impl<'a> Enumerator<'a> for str {
     /// assert_eq!(index_vec, [-3, -2, -1, 0, 1]);
     /// assert_eq!(char_vec, ['a', 'b', 'c', 'd', 'e']);
     /// ```
-    fn enumerate(&'a self, start: i32) -> PyEnumerate<Self::Item> {
-        PyEnumerate::new(self.chars(), start)
+    fn enumerate(&'a self, start: i32) -> Zip<Range<i32>, Self::Item> {
+        (start..self.len() as i32).zip(self.chars())
     }
 }
 
 impl<'a> Enumerator<'a> for String {
     type Item = Chars<'a>;
 
-    fn enumerate(&'a self, start: i32) -> PyEnumerate<Self::Item> {
-        PyEnumerate::new(self.chars(), start)
+    fn enumerate(&'a self, start: i32) -> Zip<Range<i32>, Self::Item> {
+        (start..self.len() as i32).zip(self.chars())
     }
 }
 
 impl<'a, T: 'a> Enumerator<'a> for Vec<T> {
     type Item = Iter<'a, T>;
 
-    fn enumerate(&'a self, start: i32) -> PyEnumerate<Self::Item> {
-        PyEnumerate::new(self.iter(), start)
+    fn enumerate(&'a self, start: i32) -> Zip<Range<i32>, Self::Item> {
+        (start..self.len() as i32).zip(self.iter())
     }
 }
 
 impl<'a, T: 'a, const N: usize> Enumerator<'a> for [T; N] {
     type Item = Iter<'a, T>;
 
-    fn enumerate(&'a self, start: i32) -> PyEnumerate<Self::Item> {
-        PyEnumerate::new(self.iter(), start)
+    fn enumerate(&'a self, start: i32) -> Zip<Range<i32>, Self::Item> {
+        (start..self.len() as i32).zip(self.iter())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 mod enumerate;
 mod input;
 pub mod string;
+pub mod time;
 
 pub use crate::enumerate::Enumerator;
 pub use crate::input::input;

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,5 @@
+use std::{thread, time::Duration};
+
+pub fn sleep(secs: u64) {
+    thread::sleep(Duration::from_secs(secs));
+}

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,5 +1,21 @@
+//! [Python の time モジュール](https://docs.python.org/ja/3/library/time.html) に対応するモジュール。
+
 use std::{thread, time::Duration};
 
+/// 指定した秒数、スリープする。
+///
+/// # Examples
+///
+/// ```
+/// use rspy::time::sleep;
+/// use std::time::{Duration, Instant};
+///
+/// let now = Instant::now();
+///
+/// sleep(1);
+///
+/// assert!(now.elapsed() >= Duration::from_secs(1));
+/// ```
 pub fn sleep(secs: u64) {
     thread::sleep(Duration::from_secs(secs));
 }


### PR DESCRIPTION
- Add TODO: pathlib.Path.mkdir
- リンク定義に抽出
- テーブルのソースコードをスッキリさせる
- Add rspy::Enumerator::enumerate doc link
- Add python string constants example
- rustdoc_scrape_examples を諦めない
- `PyEnumerate` を削除し、`enumerate` は `Zip` を返すように変更
- Add test: string_enumerate_works
- Refactor doc
- Install tempfile
- Add time::sleep
- Add doc: time::sleep
